### PR TITLE
Set line wrap length at 72

### DIFF
--- a/net/ietf/wrap.d
+++ b/net/ietf/wrap.d
@@ -68,7 +68,7 @@ Paragraph[] unwrapText(string text, bool flowed, bool delsp)
 	return paragraphs;
 }
 
-enum DEFAULT_WRAP_LENGTH = 66;
+enum DEFAULT_WRAP_LENGTH = 72;
 
 string wrapText(Paragraph[] paragraphs, int margin = DEFAULT_WRAP_LENGTH)
 {


### PR DESCRIPTION
Line wrap length 72 is popular in git [1] and linux kernel [2] communities. It would be nice, if DFeed has the same.

[1] http://wiki.eclipse.org/Linux_Tools_Project/Git
[2] torvalds/linux#17 (comment)
