### PR TITLE
Add dub package file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,13 @@
 *.ilk
 *.exp
 *.lib
+
+*.[oa]
+*.so
+*.dll
+
+.dub
+dub.selections.json
+
+# demos
+demo/http/ae-http-demo

--- a/demo/http/dub.json
+++ b/demo/http/dub.json
@@ -1,0 +1,15 @@
+{
+  "name": "ae-http-demo",
+  "mainSourceFile": "httpserve.d",
+  "targetType": "executable",
+
+  "dependencies": {
+    "ae": ">=1.0.0"
+  },
+
+  "dependencies /* local (disabled) */": {
+    "ae": {
+      "path": "../../"
+    }
+  }
+}

--- a/dub.json
+++ b/dub.json
@@ -1,0 +1,80 @@
+{
+  "name": "ae",
+  "description": "CyberShadow's ArmageddonEngine utilites for almost everything",
+  "homepage": "https://github.com/CyberShadow/ae",
+  "license": "MPL-2.0",
+
+  "targetType": "sourceLibrary",
+
+  "authors": [
+    "CyberShadow (Vladimir Panteleev)"
+  ],
+
+  "systemDependencies": "curl, sqlite3",
+  "libs-posix" : ["curl", "sqlite3"],
+
+  "dependencies": {
+    "openssl": {
+      "version": ">=1.1.3+1.0.1g",
+      "optional": true
+    }
+  },
+
+  "subPackages": [
+    {
+      "name": "net-http-server",
+      "targetType": "sourceLibrary",
+      "sourceFiles": [
+        "net/http/server.d",
+        "net/http/server.d",
+        "net/http/common.d",
+        "net/asockets.d",
+        "net/ietf/url.d",
+        "net/ietf/headers.d",
+        "net/ietf/headerparse.d",
+        "sys/data.d",
+        "sys/log.d",
+        "sys/file.d",
+        "sys/timing.d",
+        "sys/dataset.d",
+        "sys/signals.d",
+        "utils/aa.d",
+        "utils/appender.d",
+        "utils/meta/package.d",
+        "utils/meta/misc.d",
+        "utils/meta/reference.d",
+        "utils/meta/x.d",
+        "utils/meta/proxy.d",
+        "utils/meta/binding_v1.d",
+        "utils/meta/binding.d",
+        "utils/meta/caps.d",
+        "utils/regex.d",
+        "utils/math.d",
+        "utils/container.d",
+        "utils/text.d",
+        "utils/textout.d",
+        "utils/array.d",
+        "utils/time.d",
+        "utils/zlib.d",
+        "utils/gzip.d",
+        "utils/alloc.d",
+        "net/shutdown.d",
+        "sys/shutdown.d"
+      ],
+    }
+  ],
+
+  "sourcePaths": [ "." ],
+  "importPaths": [ "." ],
+
+  "excludedSourceFiles": [
+    "demo/*",
+    "*sdl*",
+    "sys/vfs_curl.d",
+    "sys/net/wininet.d",
+    "sys/windows/*",
+    "ui/app/windows/*",
+    "sys/benchmark.d",
+    "*/main.d"
+  ]
+}


### PR DESCRIPTION
It compiling well.

I disable:
- demos
- windows' specific staff
- sdl2 (error in compiling, may be because of new version)
  
  I try to add `derelict-sdl2` in dependencies but it have error in `SDL_FreeSurface` in utils/graphics/sdl2image.d
- `sys/vfs_curl.d` - it says:
  
  ```
  sys/vfs_curl.d(14): Error: Declaration expected, not 'module'
  ```
- `ui/app/main.d`, `ui/app/posix/main.d`, `ui/app/windows/main.d` - it have `main` function, making conflicts
- `sys/benchmark.d` also have some errors:

```
sys/benchmark.d(48): Error: undefined identifier HANDLE
sys/benchmark.d(48): Error: undefined identifier GetCurrentProcess
sys/benchmark.d(49): Error: undefined identifier HANDLE
sys/benchmark.d(49): Error: undefined identifier GetCurrentThread
sys/benchmark.d(51): Error: undefined identifier HANDLE
sys/benchmark.d(52): Error: undefined identifier OpenProcessToken
sys/benchmark.d(54): Error: undefined identifier LUID
sys/benchmark.d(55): Error: undefined identifier LookupPrivilegeValue
sys/benchmark.d(59): Error: undefined identifier TOKEN_PRIVILEGES
sys/benchmark.d(64): Error: undefined identifier AdjustTokenPrivileges
sys/benchmark.d(65): Error: undefined identifier GetLastError
sys/benchmark.d(65): Error: undefined identifier ERROR_SUCCESS
sys/benchmark.d(67): Error: undefined identifier SetPriorityClass
sys/benchmark.d(69): Error: undefined identifier SetThreadPriority
sys/benchmark.d(71): Error: undefined identifier SetProcessAffinityMask
```

Little strange thing: result package libae.a is about 37MB

I already published: http://code.dlang.org/packages/ae

---

ps. as I learn before, author don't like changes so probably it will never be merged, but can be useful for other people
