### PR TITLE
Use 'dautotest' target for transparency and easy updates

### DIFF
--- a/sys/d/manager.d
+++ b/sys/d/manager.d
@@ -1718,10 +1718,12 @@ EOS";
 				string[] targets =
 					[
 						config.build.components.website.diffable
-						? ["all", "verbatim", "pdf"] ~ (
-							makeSrc.indexOf("diffable-intermediaries") >= 0
-							? ["diffable-intermediaries"]
-							: ["dlangspec.html"])
+						? makeSrc.indexOf("dautotest") >= 0
+							? ["dautotest"]
+							: ["all", "verbatim", "pdf"] ~ (
+								makeSrc.indexOf("diffable-intermediaries") >= 0
+								? ["diffable-intermediaries"]
+								: ["dlangspec.html"])
 						: ["all", "verbatim", "pdf", "kindle"],
 						["test"]
 					][target];

--- a/sys/d/manager.d
+++ b/sys/d/manager.d
@@ -1684,8 +1684,8 @@ EOS";
 					getComponent(dep).submodule.clean = false;
 
 				auto makeFullName = sourceDir.buildPath(makeFileName);
-				makeFullName
-					.readText()
+				auto makeSrc = makeFullName.readText();
+				makeSrc
 					// https://github.com/D-Programming-Language/dlang.org/pull/1011
 					.replace(": modlist.d", ": modlist.d $(DMD)")
 					// https://github.com/D-Programming-Language/dlang.org/pull/1017
@@ -1719,7 +1719,7 @@ EOS";
 					[
 						config.build.components.website.diffable
 						? ["all", "verbatim", "pdf"] ~ (
-							makeFullName.readText.indexOf("diffable-intermediaries") >= 0
+							makeSrc.indexOf("diffable-intermediaries") >= 0
 							? ["diffable-intermediaries"]
 							: ["dlangspec.html"])
 						: ["all", "verbatim", "pdf", "kindle"],
@@ -1728,7 +1728,7 @@ EOS";
 
 				if (config.build.components.website.diffable)
 				{
-					if (makeFullName.readText.indexOf("DIFFABLE") >= 0)
+					if (makeSrc.indexOf("DIFFABLE") >= 0)
 						diffable = ["DIFFABLE=1"];
 					else
 						diffable = ["NODATETIME=nodatetime.ddoc"];

--- a/sys/net/wininet.d
+++ b/sys/net/wininet.d
@@ -139,6 +139,11 @@ protected:
 
 	final static void doDownload(HNet hUrl, void delegate(ubyte[]) sink)
 	{
+		doDownload(hUrl, cast(void delegate(const ubyte[])) sink);
+	}
+
+	final static void doDownload(HNet hUrl, void delegate(const ubyte[]) sink)
+	{
 		// Check HTTP status code
 		auto statusCode = hUrl.I!httpQueryNumber(HTTP_QUERY_STATUS_CODE);
 		if (statusCode != 200)

--- a/sys/net/wininet.d
+++ b/sys/net/wininet.d
@@ -16,6 +16,7 @@ module ae.sys.net.wininet;
 version(Windows):
 
 import std.array;
+import std.conv : to;
 import std.exception;
 import std.string;
 import std.typecons : RefCounted;


### PR DESCRIPTION
I wasn't sure whether I can remove the legacy checks.

See also: https://github.com/dlang/dlang.org/pull/2031