### PR TITLE
Bump default dmdVer to 2.068.2

### DIFF
--- a/sys/d/manager.d
+++ b/sys/d/manager.d
@@ -2179,7 +2179,7 @@ EOS";
 		auto dmdVer = config.build.components.dmd.bootstrap.ver;
 		if (!dmdVer)
 		{
-			dmdVer = "v2.067.1";
+			dmdVer = "v2.068.2";
 			version (Windows)
 				if (config.build.components.dmd.dmdModel != Component.CommonConfig.defaultModel)
 					dmdVer = "v2.070.2"; // dmd/src/builtin.d needs core.stdc.math.fabsl. 2.068.2 generates a dmd which crashes on building Phobos


### PR DESCRIPTION
This would make the backend conversion a little easier as 2.068 and higher doesn't generate a new `assert` template everytime it's generated.

See also:

- https://github.com/dlang/dmd/pull/7714#discussion_r178471067
- https://github.com/dlang/dmd/pull/7714#issuecomment-375150348
- https://dlang.org/changelog/2.068.0.html#fix14828-warning