### PR TITLE
ae.demo.pewpew: Reset score on respawn instead of death

### DIFF
--- a/demo/pewpew/objects.d
+++ b/demo/pewpew/objects.d
@@ -322,6 +322,7 @@ class Ship : GameObject
 		ship = this;
 		dead = spawning = true;
 		sounds ~= Sound.warpIn;
+		score = 0;
 	}
 
 	override void step(uint deltaTicks)
@@ -407,7 +408,6 @@ class Ship : GameObject
 	{
 		new Explosion(this, 0.150f);
 		dead = true;
-		score = 0;
 	}
 
 	override void render()


### PR DESCRIPTION
This fixes 2 minor issues simultaneously.

1. There was a way to earn and keep points after dying.  This should no longer be possible after this change.
2. Immediately after dying, the player was unable to view their most recent score if it wasn't higher than their previous high score.