### PR TITLE
fix shadowing alias this declaration for the new alias this implement…

### DIFF
--- a/sys/d/cache.d
+++ b/sys/d/cache.d
@@ -182,7 +182,11 @@ class TempCache : DirCacheBase
 		finalize();
 	}
 
-	alias cacheHost this; // https://issues.dlang.org/show_bug.cgi?id=5973
+	version (__NewAliasThis) {}
+	else
+	{
+		alias cacheHost this; // https://issues.dlang.org/show_bug.cgi?id=5973
+	}
 
 	override @property string name() const { return "none"; }
 
@@ -206,7 +210,12 @@ class TempCache : DirCacheBase
 class DirCache : DirCacheBase
 {
 	mixin GenerateConstructorProxies;
-	alias cacheHost this; // https://issues.dlang.org/show_bug.cgi?id=5973
+
+	version (__NewAliasThis) {}
+	else
+	{
+		alias cacheHost this; // https://issues.dlang.org/show_bug.cgi?id=5973
+	}
 
 	override @property string name() const { return "directory"; }
 


### PR DESCRIPTION
…ation

This is needed for [dmd#8378](https://github.com/dlang/dmd/pull/8378).
The new alias this implemetation fixes 5973 issue and your fix becomes erroneous. 
`__NewAliasThis` is a temporary version which is needed to transition from the old implementation to the new.

If it possible, create a new tag, please.