### PR TITLE
Replace deprecated std.digest.digest

### DIFF
--- a/sys/file.d
+++ b/sys/file.d
@@ -1943,7 +1943,7 @@ template mdFile()
 version (HAVE_WIN32)
 unittest
 {
-	import std.digest.digest : toHexString;
+	import std.digest : toHexString;
 	write("test.txt", "Hello, world!");
 	scope(exit) remove("test.txt");
 	assert(mdFile("test.txt").toHexString() == "6CD3556DEB0DA54BCA060B4C39479839");
@@ -1968,7 +1968,7 @@ template mdFileCached()
 version (HAVE_WIN32)
 unittest
 {
-	import std.digest.digest : toHexString;
+	import std.digest : toHexString;
 	write("test.txt", "Hello, world!");
 	scope(exit) remove("test.txt");
 	assert(mdFileCached("test.txt").toHexString() == "6CD3556DEB0DA54BCA060B4C39479839");

--- a/sys/install/common.d
+++ b/sys/install/common.d
@@ -199,7 +199,7 @@ final:
 				return;
 			log("Verifying " ~ target.baseName() ~ "...");
 
-			import std.digest.sha, std.digest.digest, std.stdio;
+			import std.digest.sha, std.digest, std.stdio;
 			SHA1 sha;
 			sha.start();
 			foreach (chunk; File(target, "rb").byChunk(0x10000))

--- a/utils/digest.d
+++ b/utils/digest.d
@@ -55,7 +55,7 @@ uint fastCRC(in void[] data, uint start = cast(uint)-1)
 	return crc;
 }
 
-// TODO: reimplement via std.digest.digest
+// TODO: reimplement via std.digest
 
 // Struct (for streaming)
 struct MurmurHash2A


### PR DESCRIPTION
The deprecated module should have been removed in 2.084.