### PR TITLE
utils.bitmanip: Add constructors

### DIFF
--- a/utils/bitmanip.d
+++ b/utils/bitmanip.d
@@ -24,6 +24,7 @@ struct BigEndian(T)
 	@property void _endian_value(T value) { _endian_bytes = nativeToBigEndian(OriginalType!T(value)); }
 	alias _endian_value this;
 	alias opAssign = _endian_value;
+	this(T value) { _endian_value(value); }
 }
 
 struct LittleEndian(T)
@@ -33,6 +34,7 @@ struct LittleEndian(T)
 	@property void _endian_value(T value) { _endian_bytes = nativeToLittleEndian(OriginalType!T(value)); }
 	alias _endian_value this;
 	alias opAssign = _endian_value;
+	this(T value) { _endian_value(value); }
 }
 
 unittest


### PR DESCRIPTION
Add constructors for utils/bitmanip so you can do things like:

LittleEndian!int foo = LittleEndian!int(0x12345678);