### PR TITLE
Remove two uses of fully qualified names that rely on a DMD bug

### DIFF
--- a/net/ietf/message.d
+++ b/net/ietf/message.d
@@ -37,7 +37,6 @@ import ae.utils.time;
 
 import ae.net.ietf.wrap;
 
-alias ae.utils.text.ascii.ascii ascii; // https://d.puremagic.com/issues/show_bug.cgi?id=12156
 alias std.string.indexOf indexOf;
 
 struct Xref

--- a/utils/text/package.d
+++ b/utils/text/package.d
@@ -557,8 +557,10 @@ unittest
 	assert(CIAsciiString("я") != CIAsciiString("Я"));
 }
 
+import std.uni : toLower;
+
 /// Case-insensitive Unicode string.
-alias CIUniString = NormalizedArray!(immutable(char), s => s.map!(std.uni.toLower));
+alias CIUniString = NormalizedArray!(immutable(char), s => s.map!(toLower));
 
 ///
 unittest


### PR DESCRIPTION
These fully-qualified names are not really exposed in the current scope but are accessible due to bug dlang/dmd#12215.