### PR TITLE
Skip compiling `ae.sys.btrfs` on Musl an Bionic systems

### DIFF
--- a/sys/btrfs/clone_range.d
+++ b/sys/btrfs/clone_range.d
@@ -14,6 +14,10 @@
 module ae.sys.btrfs.clone_range;
 
 version(linux):
+version (CRuntime_Bionic) {}
+else version (CRuntime_Musl) {}
+else
+{
 
 import core.stdc.errno;
 import core.sys.posix.sys.ioctl;
@@ -69,4 +73,6 @@ unittest
 	f2.close();
 	f1.close();
 	assert(std.file.read("test2.bin") == data);
+}
+
 }

--- a/sys/btrfs/extent_same.d
+++ b/sys/btrfs/extent_same.d
@@ -14,6 +14,10 @@
 module ae.sys.btrfs.extent_same;
 
 version(linux):
+version (CRuntime_Bionic) {}
+else version (CRuntime_Musl) {}
+else
+{
 
 import core.stdc.errno;
 import core.sys.posix.sys.ioctl;
@@ -143,4 +147,6 @@ unittest
 		Extent(File("test1.bin", "r+b"), 0),
 		Extent(File("test2.bin", "r+b"), 0),
 	], blockSize));
+}
+
 }


### PR DESCRIPTION
On musl libc and bionic libc systems, `ae.sys.btrfs.clone_range` and `ae.sys.btrfs.extent_same` cannot be compiled because `_IOW` and `_IOWR` templates are not supported.

This request provides a workaround for this issue by skiping the components of `ae.sys.btrfs.clone_range` and `ae.sys.btrfs.extent_same` on musl and bionic systems.

It enables us to use tools that depends on `ae` such as [digger](https://github.com/CyberShadow/Digger).