### PR TITLE
ae.utils.jsonrpc: Ignore unknown members in protocol objects

### DIFF
--- a/net/jsonrpc/codec.d
+++ b/net/jsonrpc/codec.d
@@ -20,6 +20,7 @@ module ae.net.jsonrpc.codec;
 import std.exception : assumeUnique;
 
 import ae.net.asockets : IConnection, DisconnectType;
+version(unittest) import ae.net.asockets : ConnectionState;
 import ae.sys.data : Data;
 import ae.utils.array : asBytes;
 import ae.utils.serialization.json;
@@ -222,6 +223,58 @@ private:
 		catch (Exception e)
 			assert(false, e.msg);
 	}
+}
+
+debug(ae_unittest) unittest
+{
+	import ae.utils.promise : resolve;
+
+	// A peer may add members to the request object as its protocol
+	// evolves. JSON-RPC 2.0 specifies the member set but does not oblige
+	// implementations to reject extra members, and a codec that fails on
+	// them cannot interoperate across peer versions.
+	static class MockConnection : IConnection
+	{
+		ReadDataHandler readHandler;
+		string disconnectReason;
+		bool disconnected;
+
+		@property ConnectionState state() { return ConnectionState.connected; }
+
+		void send(scope Data[] data, int priority = DEFAULT_PRIORITY) {}
+		alias send = IConnection.send;
+
+		void disconnect(string reason = defaultDisconnectReason, DisconnectType type = DisconnectType.requested)
+		{
+			disconnected = true;
+			disconnectReason = reason;
+		}
+		@property void handleConnect(ConnectHandler value) {}
+		@property void handleReadData(ReadDataHandler value) { readHandler = value; }
+		@property void handleDisconnect(DisconnectHandler value) {}
+		@property void handleBufferFlushed(BufferFlushedHandler value) {}
+	}
+
+	string[] dispatched;
+	auto conn = new MockConnection;
+	auto codec = new JsonRpcCodec(conn);
+	codec.handleRequest = (JsonRpcRequest request) {
+		dispatched ~= request.method;
+		return resolve(JsonRpcResponse.success(request.id, 0));
+	};
+
+	// Unknown top-level member, and no "jsonrpc" member at all.
+	conn.readHandler(Data(
+		`{"method":"peer/notify","params":{},"emittedAtMs":1}`.asBytes));
+	assert(dispatched == ["peer/notify"], dispatched.length ? dispatched[0] : "(none)");
+	assert(!conn.disconnected, conn.disconnectReason);
+
+	// Same, in a batch.
+	dispatched = null;
+	conn.readHandler(Data(
+		`[{"method":"a","extra":1},{"method":"b","extra":2}]`.asBytes));
+	assert(dispatched == ["a", "b"]);
+	assert(!conn.disconnected, conn.disconnectReason);
 }
 
 /// Convenience alias for server-only usage.

--- a/utils/jsonrpc.d
+++ b/utils/jsonrpc.d
@@ -70,6 +70,7 @@ string getDefaultErrorMessage(int code)
 // ************************************************************************
 
 /// JSON-RPC 2.0 Error object
+@JSONPartial
 struct JsonRpcError
 {
 	/// Error code
@@ -127,6 +128,7 @@ class JsonRpcException : Exception
 // ************************************************************************
 
 /// JSON-RPC 2.0 Request object
+@JSONPartial
 struct JsonRpcRequest
 {
 	/// Protocol version (always "2.0")
@@ -172,6 +174,7 @@ struct JsonRpcRequest
 }
 
 /// JSON-RPC 2.0 Response object
+@JSONPartial
 struct JsonRpcResponse
 {
 	/// Protocol version (always "2.0")


### PR DESCRIPTION
JSON-RPC peers gain members in the objects they send as their protocols evolve. The JSON-RPC 2.0 specification enumerates the members of the request, response and error objects, but does not require an implementation to reject additional ones, so a codec that rejects them cannot interoperate across peer versions.

Here the rejection is also disproportionately severe. `deserializeTo!JsonRpcRequest` throws `Unknown field <name>`, and `JsonRpcCodec.processRequests` translates that into an assert:

```d
catch (Exception e)
    assert(false, "Unexpected exception in processRequests: " ~ e.msg);
```

In a release build `assert(false)` is a halt instruction, so one unrecognized member from a peer terminates the whole process, and without a message. For contrast, `processMessage` two functions above handles the same class of failure with `doDisconnect("Malformed message: " ~ e.msg)`.

### Trigger seen in the wild

`openai-codex` 0.145.0 emits an `app-server` notification of this shape (host-specific values elided):

```json
{"method":"remoteControl/status/changed",
 "params":{"status":"disabled","serverName":"...",
           "installationId":"...","environmentId":null},
 "emittedAtMs":1784741558897}
```

The top-level `emittedAtMs` member is not part of the JSON-RPC request object. An ae-based client reading that notification dies with `SIGILL` (`si_code: ILL_ILLOPN`) the moment it arrives, and since the halt carries no message, nothing is logged to explain it.

The same notification also omits `"jsonrpc":"2.0"`, which the specification does require. That part is already harmless: the field simply defaults to `JSONRPC_VERSION`, and is not validated.

### The change

`@JSONPartial` on `JsonRpcRequest`, `JsonRpcResponse` and `JsonRpcError`, the three structs deserialized from peer input, so unknown members are drained rather than throwing.

### Test

A `debug(ae_unittest) unittest` in `ae.net.jsonrpc.codec` drives the codec through its connection's read handler with a request carrying an unknown member, both single and batched, and asserts that both dispatch without the connection being disconnected.

Removing the three annotations makes that test fail at the `assert(false)` in `processRequests`, so it covers exactly the path described above rather than just the deserializer.

`dub test --debug=ae_unittest`: 146 modules pass.

### Scope

This only stops the codec from rejecting such messages. It deliberately leaves the `assert(false)` alone, since that is a separate concern: a genuinely undeserializable request still halts the process instead of dropping the one connection. Happy to follow up on that separately if you want it changed.